### PR TITLE
Set NEML path to absolute.  Fixes #97.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "contrib/neml"]
 	path = contrib/neml
-	url = ../../Argonne-National-Laboratory/neml.git
+	url = https://github.com/Argonne-National-Laboratory/neml.git
 	ignore = untracked


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [MOOSE Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Changed the NEML submodule path to absolute so that people forking it off of public GitHub
* Don't have to change the path to absolute it independently
* Aren't at risk of accidentally changing it back when merging in INL code  

Closes #97.