### PR TITLE
Add MOOSE-based SQA templates to BlackBear

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -23,6 +23,7 @@ Extensions:
         Input Structure: getting_started/BlackBearInputStructure.md
       Code Reference:
         Systems: syntax/index.md
+        Software Quality: sqa/blackbear_index.md
 
   MooseDocs.extensions.appsyntax:
     executable: ${ROOT_DIR}
@@ -44,7 +45,29 @@ Extensions:
   MooseDocs.extensions.acronym:
     acronyms: !include ${MOOSE_DIR}/framework/doc/acronyms.yml
 
+  MooseDocs.extensions.template:
+        active: True
   MooseDocs.extensions.sqa:
-    requirement-groups:
-      dgkernels: DGKernel Objects
-      interfacekernels: InterfaceKernel Objects
+      active: True
+      repos:
+          default: https://github.com/idaholab/blackbear
+          moose: https://github.com/idaholab/moose
+      categories:
+          framework: !include ${MOOSE_DIR}/framework/doc/sqa_framework.yml
+          tensor_mechanics: !include ${MOOSE_DIR}/modules/tensor_mechanics/doc/sqa_tensor_mechanics.yml
+          stochastic_tools: !include ${MOOSE_DIR}/modules/stochastic_tools/doc/sqa_stochastic_tools.yml
+          contact: !include ${MOOSE_DIR}/modules/contact/doc/sqa_contact.yml
+          heat_conduction: !include ${MOOSE_DIR}/modules/heat_conduction/doc/sqa_heat_conduction.yml
+          misc: !include ${MOOSE_DIR}/modules/misc/doc/sqa_misc.yml
+          xfem: !include ${MOOSE_DIR}/modules/xfem/doc/sqa_xfem.yml
+          blackbear:
+              specs:
+                  - tests
+              directories:
+                  - ${ROOT_DIR}/test/tests
+      requirement-groups:
+          dgkernels: DGKernel Objects
+          interfacekernels: InterfaceKernel Objects
+  MooseDocs.extensions.bibtex:
+   duplicates:
+      - hales15homogenization

--- a/doc/content/sqa/blackbear_index.md
+++ b/doc/content/sqa/blackbear_index.md
@@ -1,0 +1,14 @@
+# Software Quality Documentation
+
+BlackBear, as one of the MOOSE-herd software codes, follows software quality
+assurance practices modeled after the American Society of Mechanical Engineers'
+Nuclear Quality Assurance program. Some of the software quality documents
+developed as part of these efforts include:
+
+- [System Requirement Specification (SRS)](sqa/blackbear_srs.md)
+- [System Design Description (SDD)](sqa/blackbear_sdd.md)
+- [Software Test Plan (STP)](sqa/blackbear_stp.md)
+- [Requirements Traceability Matrix (RTM)](sqa/blackbear_rtm.md)
+- [Verification and Validation Results Report](sqa/blackbear_vvr.md)
+
+A tagged version of BlackBear has not yet been released.

--- a/doc/content/sqa/blackbear_rtm.md
+++ b/doc/content/sqa/blackbear_rtm.md
@@ -1,0 +1,1 @@
+!template load file=app_rtm.md.template app=BlackBear category=blackbear

--- a/doc/content/sqa/blackbear_sdd.md
+++ b/doc/content/sqa/blackbear_sdd.md
@@ -1,0 +1,1 @@
+!template load file=app_sdd.md.template app=BlackBear category=blackbear

--- a/doc/content/sqa/blackbear_srs.md
+++ b/doc/content/sqa/blackbear_srs.md
@@ -1,0 +1,1 @@
+!template load file=app_srs.md.template app=BlackBear category=blackbear

--- a/doc/content/sqa/blackbear_stp.md
+++ b/doc/content/sqa/blackbear_stp.md
@@ -1,0 +1,1 @@
+!template load file=app_stp.md.template app=BlackBear category=blackbear

--- a/doc/content/sqa/blackbear_vrr.md
+++ b/doc/content/sqa/blackbear_vrr.md
@@ -1,0 +1,1 @@
+!template load file=app_vvr.md.template app=BlackBear category=blackbear

--- a/doc/content/sqa/blackbear_vvr.md
+++ b/doc/content/sqa/blackbear_vvr.md
@@ -1,0 +1,2 @@
+!template load file=app_vvr.md.template app=BlackBear category=blackbear
+

--- a/test/tests/neml_simple/tests
+++ b/test/tests/neml_simple/tests
@@ -6,7 +6,7 @@
     csvdiff = 'le_stress_out.csv'
     required_objects = NEMLStress
     design = 'NEMLStress.md'
-    requirement = 'BlackBear shall be capable of using the NEML library to compute the 
+    requirement = 'BlackBear shall be capable of using the NEML library to compute the
                    response of a linearly elastic material parsed from xml'
   [../]
   [./neml_linear_elastic_variableOverwrite]
@@ -15,9 +15,9 @@
     csvdiff = 'le_stress_out.csv'
     required_objects = NEMLStress
     design = 'NEMLStress.md'
-    requirement = 'BlackBear shall be capable of using the NEML library to compute the 
-                   response of a linearly elastic material parsed from xml.  
-                   Parameters defined in the xml can be overwritten by up to five 
+    requirement = 'BlackBear shall be capable of using the NEML library to compute the
+                   response of a linearly elastic material parsed from xml.
+                   Parameters defined in the xml can be overwritten by up to five
                    variables in the input file.'
   [../]
   [./neml_linear_elastic_simpleMaterial]
@@ -28,7 +28,7 @@
     required_objects = NEMLStress
     allow_test_objects = true
     design = 'NEMLStress.md'
-    requirement = 'BlackBear shall be capable of using the NEML library to compute the 
+    requirement = 'BlackBear shall be capable of using the NEML library to compute the
                    response of a linearly elastic material defined in a material class'
   [../]
   [./neml_linear_elastic_thermal]
@@ -36,9 +36,9 @@
     input = 'le_stress_thermal.i'
     csvdiff = 'le_stress_thermal_out.csv'
     required_objects = 'NEMLStress NEMLThermalExpansionEigenstrain'
-    design = 'NEMLStress.md ThermalExpansionEigenstrainNEML.md'
-    requirement = 'BlackBear shall be capable of using the NEML library to compute the 
-                   response of a linearly elastic material and also use NEML to apply 
+    design = 'NEMLStress.md NEMLThermalExpansionEigenstrain.md'
+    requirement = 'BlackBear shall be capable of using the NEML library to compute the
+                   response of a linearly elastic material and also use NEML to apply
                    a thermal expansion'
   [../]
 []


### PR DESCRIPTION
Pulls in the templates for the following SQA documents from MOOSE:

- System Requirement Specification (SRS)
- System Design Description (SDD)
- Software Test Plan (STP)
- Requirements Traceability Matrix (RTM)
- Verification and Validation Results Report

and added a Software Quality page to the Code Reference tab

Refs #127
