### PR TITLE
Use parallel scheduling on concrete tests

### DIFF
--- a/assessment/asr_validation/wald2017B/analysis/assessment
+++ b/assessment/asr_validation/wald2017B/analysis/assessment
@@ -3,6 +3,7 @@
   requirement = 'BlackBear shall simulate accelerated alkali-silica reaction experiments on
                  plain and reinforced concrete blocks, and adequately match experimental data.'
   design = 'wald2017B.md'
+  parallel_scheduling = true
 
   [./conc_time0]
     type = 'CSVDiff'


### PR DESCRIPTION
ref #83

This allows them to run simultaneously, which should drastically
decrease the time for nightly tests to complete.