### PR TITLE
Correcting use_legacy_dirichlet_bc and use_legacy_material_output in BlackBearApp

### DIFF
--- a/src/base/BlackBearApp.C
+++ b/src/base/BlackBearApp.C
@@ -23,6 +23,11 @@ InputParameters
 BlackBearApp::validParams()
 {
   InputParameters params = MooseApp::validParams();
+
+  // Do not use legacy DirichletBC, that is, set DirichletBC default for preset = true
+  params.set<bool>("use_legacy_dirichlet_bc") = false;
+  params.set<bool>("use_legacy_material_output") = false;
+
   return params;
 }
 

--- a/test/tests/concrete_sulfide_attack/sulfide_attack.i
+++ b/test/tests/concrete_sulfide_attack/sulfide_attack.i
@@ -57,30 +57,35 @@
 [BCs]
   [./ca_left]
     type = DirichletBC
+    preset = false
     variable = ca
     boundary = 3
     value = 1.0e-2
   [../]
   [./cl-_left]
     type = DirichletBC
+    preset = false
     variable = cl
     boundary = 3
     value = 2.0e-2
   [../]
   [./h+_left]
     type = DirichletBC
+    preset = false
     variable = h
     boundary = 3
     value = 1.0e-10
   [../]
   [./na+_left]
     type = DirichletBC
+    preset = false
     variable = na
     boundary = 3
     value = 1.0e-5
   [../]
   [./so42-_left]
     type = DirichletBC
+    preset = false
     variable = so4
     boundary = 3
     value = 1.0e-5
@@ -94,6 +99,7 @@
 #   [../]
   [./cl-_right]
     type = DirichletBC
+    preset = false
     variable = cl
     boundary = 1
     value = 1.0e-5
@@ -106,12 +112,14 @@
 #   [../]
   [./na+_right]
     type = DirichletBC
+    preset = false
     variable = na
     boundary = 1
     value = 2.0e-2
   [../]
   [./so42-_right]
     type = DirichletBC
+    preset = false
     variable = so4
     boundary = 1
     value = 1.0e-2


### PR DESCRIPTION
This PR adds use_legacy_dirichlet_bc and use_legacy_material_output parameters in the BlackBearApp.C so that BlackBearApp runs the input file in the same way as TensorMechanics module. One example of such file is "moose/modules/tensor_mechanics/test/tests/2D_geometries/2D-RZ_finiteStrain_resid.i"
close #177 