### PR TITLE
Clean up NEML coupling material

### DIFF
--- a/include/materials/NEMLStress.h
+++ b/include/materials/NEMLStress.h
@@ -17,62 +17,49 @@
 #include "NEMLStressBase.h"
 #include "neml_interface.h"
 
+#include <string>
+#include <vector>
+#include <set>
+
 /**
  * NEMLStress computes the stress using a constitutive model provided by the NEML library.
- * Parameters for that model are defined in an xml file and optionally in the input file.
+ * Parameters for that model are defined in an XML file and optionally in the input file.
  */
-
 class NEMLStress : public NEMLStressBase
 {
 public:
   static InputParameters validParams();
   NEMLStress(const InputParameters & parameters);
 
-private:
-  /**
-   * Get values from the input file that will be substituted in for the nemlNames provided in the
-   *input file
-   * @param nemlNames variables names from input file
-   * @return vector containing the values that will be substituted in for the each nemlNames
-   **/
-  std::vector<Real> constructNemlSubstitutionList(const std::vector<std::string> & nemlNames) const;
+protected:
+  /// list of {variable} names for substitution in the XML file
+  std::vector<std::string> _neml_variable_iname;
 
-  /**
-   * Error checking: find strings in string list 1 that are not found in string list 2
-   * @param strList1
-   * @param strList2
-   * @return return strings from strList1 not found in strList2
-   **/
-  std::string compareVectorsOfStrings(const std::vector<std::string> & strList1,
-                                      const std::vector<std::string> & strList2) const;
+  /// Vector of values to substitute in
+  std::vector<Real> _neml_variable_value;
 
-  /**
-   * Parse the xml file into a string
-   * @param fname xml file name to be read in
-   * @return string containing file contents
-   **/
-  std::string loadFileIntoString(const FileName & fname) const;
+  /// Number of {variables{ to substitute in the XML}}
+  const std::size_t _nvars;
 
-  /**
-   * Get a list of variable names specified in the xml file
-   * @param xmlStringForNeml string containing xml file
-   * @return list of the variable names found in the xml file.
-   **/
-  std::vector<std::string> listOfVariablesInXml(const std::string & xmlStringForNeml) const;
+  /// set of variables in the XML file
+  std::set<std::string> _xml_vars;
 
-  /**
-   * Check that all variable names in xml file are also in the input file and vice versa
-   * @param nemlNames variables names from input file
-   * @param xmlStringForNeml string containing the xml file
-   **/
-  void errorCheckVariableNamesFromInputFile(const std::vector<std::string> & nemlNames,
-                                            const std::string & xmlStringForNeml) const;
+  /// max number of numbered value parameters (neml_variable_value0, neml_variable_value1, ...)
+  static const std::size_t _nvars_max = 8;
 
-  /**
-   * Substitute values in for the variables names found in the string version of the xml file
-   * @param xmlStringForNeml string containing the xml file, returned version of this string has
-   *values substituted in for variables names
-   **/
+  /// NEML XML Input
+  std::string _xml;
 
-  void replaceXmlVariables(std::string & xmlStringForNeml) const;
+  /// Find strings in set 1 that are not found in set 2
+  std::vector<std::string> setDifference(const std::set<std::string> & set1,
+                                         const std::set<std::string> & set2) const;
+
+  /// Build a set of variable names specified in the xml file
+  void findXMLVariables();
+
+  /// Check that all variable names in xml file are also in the input file and vice versa
+  void errorCheckXMLVariables() const;
+
+  /// Substitute values in for the variables names found in the string version of the xml file
+  void replaceXMLVariables();
 };

--- a/include/materials/NEMLStressBase.h
+++ b/include/materials/NEMLStressBase.h
@@ -35,30 +35,33 @@ public:
 protected:
   /// NEML model
   std::unique_ptr<neml::NEMLModel> _model;
-  /// History variables used by NEML model
-  ///@{
+
+  ///@{ History variables used by NEML model
   MaterialProperty<std::vector<Real>> & _hist;
   const MaterialProperty<std::vector<Real>> & _hist_old;
   ///@}
+
   /// Old mechanical strain
   const MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
+
   /// Old stress
   const MaterialProperty<RankTwoTensor> & _stress_old;
-  /// Strain energy
-  ///@{
+
+  ///@{ Strain energy
   MaterialProperty<Real> & _energy;
   const MaterialProperty<Real> & _energy_old;
   ///@}
-  /// Dissipation
-  ///@{
+
+  ///@{ Dissipation
   MaterialProperty<Real> & _dissipation;
   const MaterialProperty<Real> & _dissipation_old;
   ///@}
-  /// Coupled temperature variable (defaults to zero if not specified)
-  ///@{
+
+  ///@{ Coupled temperature variable (defaults to zero if not specified)
   const VariableValue & _temperature;
   const VariableValue & _temperature_old;
   ///@}
+
   /// Inelastic strain tensor
   MaterialProperty<RankTwoTensor> & _inelastic_strain;
 
@@ -72,20 +75,20 @@ protected:
    * format.
    * @param in  RankTwoTensor to be translated
    * @param out NEML vector output
-   **/
-  void RankTwoTensorToNeml(const RankTwoTensor & in, double * const out);
+   */
+  void rankTwoTensorToNeml(const RankTwoTensor & in, double * const out);
 
   /**
    * Translates a NEML tensor stored in vector format to a RankTwoTensor.
    * @param in  NEML vector to be translated
    * @param out RankTwoTensor output
-   **/
-  void NemlToRankTwoTensor(const double * const in, RankTwoTensor & out);
+   */
+  void nemlToRankTwoTensor(const double * const in, RankTwoTensor & out);
 
   /**
    * Translates a NEML elasticity tensor to a RankFourTensor.
    * @param in  NEML elasticity tensor to be translated
    * @param out RankFourTensor output
-   **/
-  void NemlToRankFourTensor(const double * const in, RankFourTensor & out);
+   */
+  void nemlToRankFourTensor(const double * const in, RankFourTensor & out);
 };

--- a/src/materials/NEMLStress.C
+++ b/src/materials/NEMLStress.C
@@ -84,10 +84,13 @@ NEMLStress::NEMLStress(const InputParameters & parameters)
   std::ifstream t(fname.c_str());
   _xml.assign((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
 
-  // replace {variables} in the XML file
-  findXMLVariables();
-  errorCheckXMLVariables();
-  replaceXMLVariables();
+  // replace {variables} in the XML file (the _nvars > 0 is an ugly hack)
+  if (_nvars > 0)
+  {
+    findXMLVariables();
+    errorCheckXMLVariables();
+    replaceXMLVariables();
+  }
 
   // build NEML model object
   auto mname = getParam<std::string>("model");

--- a/src/materials/NEMLStress.C
+++ b/src/materials/NEMLStress.C
@@ -37,8 +37,10 @@ NEMLStress::validParams()
   for (size_t i = 0; i < _nvars_max; ++i)
   {
     auto istr = Moose::stringify(i);
-    params.addParam<Real>("neml_variable_value" + istr,
-                          "NEML XML variable value for neml_variable_iname[" + istr + "]");
+    params.addDeprecatedParam<Real>(
+        "neml_variable_value" + istr,
+        "NEML XML variable value for neml_variable_iname[" + istr + "]",
+        "Deprecated in favor of the 'neml_variable_value' vector of names parameter");
   }
   return params;
 }

--- a/test/tests/neml_simple/le_stress_variableOverwrite.i
+++ b/test/tests/neml_simple/le_stress_variableOverwrite.i
@@ -219,8 +219,7 @@
     database = 'examples.xml'
     model = variable_example
     neml_variable_iname = 'PoissonsVar YoungsVar'
-    neml_variable_value1=100000
-    neml_variable_value0=0.3
+    neml_variable_value = '0.3         100000'
   []
 []
 

--- a/test/tests/neml_simple/tests
+++ b/test/tests/neml_simple/tests
@@ -17,8 +17,7 @@
     design = 'NEMLStress.md'
     requirement = 'BlackBear shall be capable of using the NEML library to compute the
                    response of a linearly elastic material parsed from xml.
-                   Parameters defined in the xml can be overwritten by up to five
-                   variables in the input file.'
+                   Parameters defined in the xml can be overwritten by variables in the input file.'
   [../]
   [./neml_linear_elastic_simpleMaterial]
     issues = '#78'

--- a/test/tests/neml_stochasticSimple/le_stress_simple.i
+++ b/test/tests/neml_stochasticSimple/le_stress_simple.i
@@ -219,8 +219,7 @@
     database = 'examples.xml'
     model = variable_example
     neml_variable_iname = 'YoungsVar PoissonsVar'
-    neml_variable_value0=100000
-    neml_variable_value1=0.3
+    neml_variable_value = '100000    0.3'
   []
 []
 

--- a/test/tests/neml_stochasticSimple/stochastic_driver.i
+++ b/test/tests/neml_stochasticSimple/stochastic_driver.i
@@ -72,11 +72,12 @@
 
 [Controls]
   [cmdLine]
-    type=MultiAppCommandLineControl
-    multi_app=sub
-    sampler=neml_values
-    param_names='Materials/stress/neml_variable_value0
-                 Materials/stress/neml_variable_value1'
+    type = MultiAppCommandLineControl
+    multi_app = sub
+    sampler = neml_values
+
+    param_names='Materials/stress/neml_variable_value[0,1]'
+
   []
 []
 


### PR DESCRIPTION
- make sure types match
- make things constant
- fix index types
- permit supplying XML substitution values as a vector parameter
- simplify and extend error checking (detect duplicate inames)
- substitute _all_ occurrences of a {variable} (and simplify substitution code)
- don't pass around stuff as parameters that should be members