### PR TITLE
Include location for CIVET results in documentation config

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -50,6 +50,7 @@ Extensions:
             moose:
                 url: https://civet.inl.gov
                 repo: idaholab/moose
+                location: ${MOOSE_DIR}
 
     MooseDocs.extensions.sqa:
         active: True


### PR DESCRIPTION
(fixes #213)

You will need to wait for the idaholab/moose#17844 to become the submodule.

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [MOOSE Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
