### PR TITLE
Minor SQA doc cleanup

### DIFF
--- a/doc/content/sqa/index.md
+++ b/doc/content/sqa/index.md
@@ -1,6 +1,6 @@
 !template load file=app_index.md.template app=BlackBear category=blackbear
 
-{app} employs a continuous integration strategy using [!ac](CIVET); the testing results for
+BlackBear employs a continuous integration strategy using [!ac](CIVET); the testing results for
 this version of the documentation is available at the following links:
 
 !civet mergeresults

--- a/doc/sqa_reports.yml
+++ b/doc/sqa_reports.yml
@@ -36,3 +36,4 @@ Requirements:
             - test/tests
         log_testable: WARNING
         show_warning: false
+        include_non_testable: true


### PR DESCRIPTION
 ref #127

1) Minor wording fix for links to releases
2) Turn warnings about skipped tests back on in the SQA report
