### PR TITLE
Update NEML to newest version

### DIFF
--- a/test/tests/neml_regression/populate_tests.py
+++ b/test/tests/neml_regression/populate_tests.py
@@ -8,6 +8,8 @@ neml_rtest_path = os.path.relpath(NEML_DIR + '/test/test_regression')
 dirs = []
 
 for (dirpath, dirnames, filenames) in os.walk(neml_rtest_path):
+  if '__pycache__' in dirnames:
+    dirnames.remove("__pycache__")
   dirs.extend(dirnames)
 
 try:


### PR DESCRIPTION
I finally eliminated error codes in NEML, so the interface here needs to change slightly.  This PR:

- Updates NEML to the current dev
- Uses the new NEMLError system to provide a more informative mooseError in the event of a failed stress update
- Updates the LANLTi regression test -- we keep messing with this model, sorry
- Updates the script that gathers the tests to avoid pulling in the `__pycache__` directories.  The NEML tests are now a proper python module.