### PR TITLE
Adjust BlackBear SQA documents for custom entries

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -21,7 +21,6 @@ Extensions:
     MooseDocs.extensions.navigation:
         name: BlackBear
         repo: https://github.com/idaholab/blackbear
-        home: https://mooseframework.inl.gov/blackbear/
         menu:
             Getting Started:
                 Running BlackBear: getting_started/RunningBlackBear.md

--- a/doc/content/sqa/blackbear_cci.md
+++ b/doc/content/sqa/blackbear_cci.md
@@ -1,4 +1,4 @@
-!template load file=cci.md.template app=BlackBear category=blackbear
+!template load file=app_cci.md.template app=BlackBear category=blackbear
 
 !template item key=general-communication
 Please use the [BlackBear Discussion forum](https://github.com/idaholab/blackbear/discussions) for all

--- a/doc/content/sqa/blackbear_rtm.md
+++ b/doc/content/sqa/blackbear_rtm.md
@@ -1,1 +1,1 @@
-!template load file=app_rtm.md.template app=BlackBear category=blackbear
+!template load file=app_rtm.md.template app=BlackBear category=blackbear stp_filename=blackbear_rtm.md

--- a/doc/content/sqa/blackbear_sdd.md
+++ b/doc/content/sqa/blackbear_sdd.md
@@ -1,1 +1,18 @@
 !template load file=app_sdd.md.template app=BlackBear category=blackbear
+
+!template! item key=introduction
+!alert! warning title=Introduction needs to be filled in
+An introduction to blackbear design and design goals should be placed here. If a
+reference/inspiration is desired, please refer to the [sqa/framework_sdd.md].
+!alert-end!
+!template-end!
+
+!template! item key=system-structure
+!alert! warning title=System Structure needs to be filled in
+A discussion of BlackBear architecture and its relation to that of MOOSE should
+be placed here. If a reference/inspiration is needed, please refer to the [sqa/framework_sdd.md].
+!alert-end!
+!template-end!
+
+!syntax complete subsystems=False actions=False objects=False
+!template-end!

--- a/doc/content/sqa/blackbear_srs.md
+++ b/doc/content/sqa/blackbear_srs.md
@@ -1,1 +1,6 @@
 !template load file=app_srs.md.template app=BlackBear category=blackbear
+
+!template item key=reliability
+The regression test suite will cover at least 90% of all lines of code at all times. Known
+regressions will be recorded and tracked (see [#maintainability]) to an independent and
+satisfactory resolution.


### PR DESCRIPTION
This PR adds some customization examples to the SRS and SDD, such that they can be further modified. Pending adjustments to the application SQA templates for these documents as well as the RTM will highlight gaps in template entries that need to be filled, as well as a formal template suggestion of how to fill them. In practice, developers should also look at the [framework versions of these documents](https://github.com/idaholab/moose/tree/master/framework/doc/content/sqa) as they develop their own to ensure similar content is present in both. 

The CCI was also pointed to the wrong template, and this was corrected. 

@bwspenc I would consider this PR a work in progress for now, so I am making it a draft. Would like to get the MOOSE changes in so that you can see the information boxes that should appear for gaps in the documents. 

Refs #127