### PR TITLE
Prevent name clashes for multiple EqualValueEmbeddedConstraintActions

### DIFF
--- a/doc/content/syntax/Constraints/EqualValueEmbeddedConstraint/index.md
+++ b/doc/content/syntax/Constraints/EqualValueEmbeddedConstraint/index.md
@@ -8,7 +8,7 @@ This block sets up multiple [EqualValueEmbeddedConstraint](/constraints/EqualVal
 
 ## Example Input Syntax
 
-!listing test/tests/actions/EqualValueEmbeddedConstraintAction.i block=Constraints/EqualValueEmbeddedConstraint/Batch
+!listing test/tests/actions/EqualValueEmbeddedConstraintAction.i block=Constraints/EqualValueEmbeddedConstraint/batch
 
 !syntax parameters /Constraints/EqualValueEmbeddedConstraint/EqualValueEmbeddedConstraintAction
 

--- a/src/actions/EqualValueEmbeddedConstraintAction.C
+++ b/src/actions/EqualValueEmbeddedConstraintAction.C
@@ -74,7 +74,7 @@ EqualValueEmbeddedConstraintAction::act()
     for (size_t p = 0; p < _primary.size(); p++)
       for (size_t s = 0; s < _secondary.size(); s++)
       {
-        std::string unique_constraint_name = constraint_name + "_disp_num_" + Moose::stringify(i) +
+        std::string unique_constraint_name = constraint_name + "_" + _variable[i] + "_" +
                                              "_primary_" + Moose::stringify(p) + "_secondary_" +
                                              Moose::stringify(s);
         InputParameters params = _factory.getValidParams(constraint_name);

--- a/test/tests/actions/EqualValueEmbeddedConstraintAction.i
+++ b/test/tests/actions/EqualValueEmbeddedConstraintAction.i
@@ -32,12 +32,14 @@
   [../]
 []
 
-[Constraints/EqualValueEmbeddedConstraint/Batch]
-  primary = '1'
-  secondary = '2 3'
-  variable = 'disp_x disp_y disp_z'
-  penalty = 1e12
-  formulation = penalty
+[Constraints/EqualValueEmbeddedConstraint]
+  [batch]
+    primary = '1'
+    secondary = '2 3'
+    variable = 'disp_x disp_y disp_z'
+    penalty = 1e12
+    formulation = penalty
+  []
 []
 
 [Variables]

--- a/test/tests/actions/SplitActionBlocks.i
+++ b/test/tests/actions/SplitActionBlocks.i
@@ -1,0 +1,19 @@
+[Constraints/EqualValueEmbeddedConstraint]
+  [batch]
+    primary = '1'
+    secondary = '2 3'
+    variable = 'disp_x disp_y'
+    penalty = 1e12
+    formulation = penalty
+  []
+  # Split into a second batch to test that two instances of this
+  # block can be used together. This should behave the same as
+  # listing disp_x, disp_y, and disp_z in a single block.
+  [batch2]
+    primary = '1'
+    secondary = '2 3'
+    variable = 'disp_z'
+    penalty = 1e12
+    formulation = penalty
+  []
+[]

--- a/test/tests/actions/tests
+++ b/test/tests/actions/tests
@@ -21,13 +21,23 @@
                'automatically set up multiple constraints with the same '
                'results as without using the action.'
     []
-    [primary_variable_and_variable_size_match_error]
-      type = 'RunException'
-      input = 'EqualValueEmbeddedConstraintAction.i'
-      expect_err = "Sizes of 'primary_variable' and 'variable' must match."
-      cli_args = "Constraints/EqualValueEmbeddedConstraint/Batch/primary_variable='disp_x disp_y'"
-      allow_test_objects = True
-      detail = "The EqualValueEmbeddedConstraintAction shall generate an error if sizes of 'primary_variable' and 'variable' are different"
+    [with_action_multiple_blocks]
+      prereq = EqualValueEmbeddedConstraintAction/with_action
+      type = 'Exodiff'
+      input = 'EqualValueEmbeddedConstraintAction.i SplitActionBlocks.i'
+      exodiff = 'EqualValueEmbeddedConstraint_out.e'
+      detail = 'using multiple instances of the EqualValueEmbeddedConstraint '
+               'action to set up multiple constraints with the same results '
+               'as without using the action.'
     []
+  []
+
+  [primary_variable_and_variable_size_match_error]
+    type = 'RunException'
+    input = 'EqualValueEmbeddedConstraintAction.i'
+    expect_err = "Sizes of 'primary_variable' and 'variable' must match."
+    cli_args = "Constraints/EqualValueEmbeddedConstraint/batch/primary_variable='disp_x disp_y'"
+    allow_test_objects = True
+    requirement = "The EqualValueEmbeddedConstraintAction shall generate an error if sizes of 'primary_variable' and 'variable' are different"
   []
 []


### PR DESCRIPTION
closes #299

The names of Constraint objects created by EqualValueEmbeddedConstraintAction
were not connected to variable names, which meant that if more than one instance
of that block were created to allow use with another variable, there would be
a name clash. Fix that by including the variable name in the name of the Constraint.
