### PR TITLE
Update NEML library to newest version

### DIFF
--- a/contrib/neml.mk
+++ b/contrib/neml.mk
@@ -35,4 +35,4 @@ endif
 #This executes a script that populates the regression tests that run the same models as the NEML
 #regression tests, but from BlackBear
 all:
-	cd $(BLACKBEAR_DIR)/test/tests/neml_regression && NEML_DIR=$(NEML_DIR) ./populate_tests.py
+	cd $(BLACKBEAR_DIR)/test/tests/neml_regression && NEML_DIR=$(NEML_DIR) ./populate_tests.py && cd $(BLACKBEAR_DIR)/test/tests/neml_regression_lagrangian && NEML_DIR=$(NEML_DIR) ./populate_tests.py

--- a/doc/content/source/materials/CauchyStressFromNEML.md
+++ b/doc/content/source/materials/CauchyStressFromNEML.md
@@ -1,0 +1,14 @@
+# CauchyStressFromNEML
+
+!syntax description /Materials/CauchyStressFromNEML
+
+This material model provides the Cauchy stress to the Lagrangian system using NEML.
+It serves the same function as the [NEMLStress](source/materials/NEMLStress.md) object, but for
+the Lagrangian solid mechanics system.
+
+!syntax parameters /Materials/CauchyStressFromNEML
+
+!syntax inputs /Materials/CauchyStressFromNEML
+
+!syntax children /Materials/CauchyStressFromNEML
+

--- a/include/materials/CauchyStressFromNEML.h
+++ b/include/materials/CauchyStressFromNEML.h
@@ -1,0 +1,67 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*                       BlackBear                              */
+/*                                                              */
+/*           (c) 2017 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#pragma once
+
+#include "ComputeLagrangianStressCauchy.h"
+
+#include "neml_interface.h"
+
+class CauchyStressFromNEML : public ComputeLagrangianStressCauchy
+{
+public:
+  static InputParameters validParams();
+  CauchyStressFromNEML(const InputParameters & parameters);
+
+protected:
+  virtual void computeQpCauchyStress();
+  virtual void initQpStatefulProperties();
+
+protected:
+  FileName _fname;
+  std::string _mname;
+  std::unique_ptr<neml::NEMLModel> _model;
+
+  const VariableValue & _temperature;
+  const VariableValue & _temperature_old;
+
+  MaterialProperty<std::vector<Real>> & _history;
+  const MaterialProperty<std::vector<Real>> & _history_old;
+
+  MaterialProperty<Real> & _energy;
+  const MaterialProperty<Real> & _energy_old;
+
+  MaterialProperty<Real> & _dissipation;
+  const MaterialProperty<Real> & _dissipation_old;
+
+  MaterialProperty<RankTwoTensor> & _linear_rotation;
+  const MaterialProperty<RankTwoTensor> & _linear_rotation_old;
+
+  const MaterialProperty<RankTwoTensor> & _cauchy_stress_old;
+
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain;
+  const MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
+
+  MaterialProperty<RankTwoTensor> & _inelastic_strain;
+  MaterialProperty<RankTwoTensor> & _elastic_strain;
+
+  MaterialProperty<Real> & _dissipation_rate;
+};
+
+/// Tensor -> skew vector
+void rankTwoSkewToNEML(const RankTwoTensor & in, double * const out);
+
+/// Skew + symmetric parts to full tangent
+void
+recombineTangentNEML(const double * const Dpart, const double * const Wpart, RankFourTensor & out);

--- a/include/materials/NEMLStressBase.h
+++ b/include/materials/NEMLStressBase.h
@@ -32,6 +32,28 @@ public:
   virtual void computeQpStress() override;
   virtual void initQpStatefulProperties() override;
 
+  /**
+   * Translates a RankTwoTensor object to a NEML tensor stored in a vector
+   * format.
+   * @param in  RankTwoTensor to be translated
+   * @param out NEML vector output
+   */
+  static void rankTwoTensorToNeml(const RankTwoTensor & in, double * const out);
+
+  /**
+   * Translates a NEML tensor stored in vector format to a RankTwoTensor.
+   * @param in  NEML vector to be translated
+   * @param out RankTwoTensor output
+   */
+  static void nemlToRankTwoTensor(const double * const in, RankTwoTensor & out);
+
+  /**
+   * Translates a NEML elasticity tensor to a RankFourTensor.
+   * @param in  NEML elasticity tensor to be translated
+   * @param out RankFourTensor output
+   */
+  static void nemlToRankFourTensor(const double * const in, RankFourTensor & out);
+
 protected:
   /// NEML model
   std::unique_ptr<neml::NEMLModel> _model;
@@ -74,26 +96,4 @@ protected:
 
   /// Print debugging data on failed NEML stress updates
   const bool _debug;
-
-  /**
-   * Translates a RankTwoTensor object to a NEML tensor stored in a vector
-   * format.
-   * @param in  RankTwoTensor to be translated
-   * @param out NEML vector output
-   */
-  void rankTwoTensorToNeml(const RankTwoTensor & in, double * const out);
-
-  /**
-   * Translates a NEML tensor stored in vector format to a RankTwoTensor.
-   * @param in  NEML vector to be translated
-   * @param out RankTwoTensor output
-   */
-  void nemlToRankTwoTensor(const double * const in, RankTwoTensor & out);
-
-  /**
-   * Translates a NEML elasticity tensor to a RankFourTensor.
-   * @param in  NEML elasticity tensor to be translated
-   * @param out RankFourTensor output
-   */
-  void nemlToRankFourTensor(const double * const in, RankFourTensor & out);
 };

--- a/src/materials/CauchyStressFromNEML.C
+++ b/src/materials/CauchyStressFromNEML.C
@@ -1,0 +1,231 @@
+/****************************************************************/
+/*               DO NOT MODIFY THIS HEADER                      */
+/*                       BlackBear                              */
+/*                                                              */
+/*           (c) 2017 Battelle Energy Alliance, LLC             */
+/*                   ALL RIGHTS RESERVED                        */
+/*                                                              */
+/*          Prepared by Battelle Energy Alliance, LLC           */
+/*            Under Contract No. DE-AC07-05ID14517              */
+/*            With the U. S. Department of Energy               */
+/*                                                              */
+/*            See COPYRIGHT for full restrictions               */
+/****************************************************************/
+
+#ifdef NEML_ENABLED
+
+#include "CauchyStressFromNEML.h"
+
+#include "NEMLStressBase.h"
+
+registerMooseObject("BlackBearApp", CauchyStressFromNEML);
+
+InputParameters
+CauchyStressFromNEML::validParams()
+{
+  InputParameters params = ComputeLagrangianStressCauchy::validParams();
+
+  params.addRequiredParam<FileName>("database", "Path to NEML XML database.");
+  params.addRequiredParam<std::string>("model", "Model name in NEML database.");
+  params.addCoupledVar("temperature", 0.0, "Coupled temperature");
+
+  return params;
+}
+
+CauchyStressFromNEML::CauchyStressFromNEML(const InputParameters & parameters)
+  : ComputeLagrangianStressCauchy(parameters),
+    _fname(getParam<FileName>("database")),
+    _mname(getParam<std::string>("model")),
+    _temperature(coupledValue("temperature")),
+    _temperature_old(coupledValueOld("temperature")),
+    _history(declareProperty<std::vector<Real>>(_base_name + "history")),
+    _history_old(getMaterialPropertyOld<std::vector<Real>>(_base_name + "history")),
+    _energy(declareProperty<Real>(_base_name + "energy")),
+    _energy_old(getMaterialPropertyOld<Real>(_base_name + "energy")),
+    _dissipation(declareProperty<Real>(_base_name + "dissipation")),
+    _dissipation_old(declareProperty<Real>(_base_name + "dissipation_old")),
+    _linear_rotation(declareProperty<RankTwoTensor>(_base_name + "linear_rotation")),
+    _linear_rotation_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "linear_rotation")),
+    _cauchy_stress_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "cauchy_stress")),
+    _mechanical_strain(getMaterialProperty<RankTwoTensor>(_base_name + "mechanical_strain")),
+    _mechanical_strain_old(getMaterialPropertyOld<RankTwoTensor>(_base_name + "mechanical_strain")),
+    _inelastic_strain(declareProperty<RankTwoTensor>(_base_name + "inelastic_strain")),
+    _elastic_strain(declareProperty<RankTwoTensor>(_base_name + "elastic_strain")),
+    _dissipation_rate(declareProperty<Real>(_base_name + "dissipation_rate"))
+{
+  // Should raise an exception if it does not work
+  _model = neml::parse_xml_unique(_fname, _mname);
+}
+
+void
+CauchyStressFromNEML::computeQpCauchyStress()
+{
+  // Setup all the Mandel notation things we need
+  double s_np1[6];
+  double s_n[6];
+  NEMLStressBase::rankTwoTensorToNeml(_cauchy_stress_old[_qp], s_n);
+
+  // Strain
+  double e_np1[6];
+  NEMLStressBase::rankTwoTensorToNeml(_mechanical_strain[_qp], e_np1);
+  double e_n[6];
+  NEMLStressBase::rankTwoTensorToNeml(_mechanical_strain_old[_qp], e_n);
+
+  // Vorticity
+  RankTwoTensor L;
+  if (_large_kinematics)
+  {
+    L = RankTwoTensor::Identity() - _inv_df[_qp];
+  }
+  else
+  {
+    L.zero();
+  }
+  _linear_rotation[_qp] = _linear_rotation_old[_qp] + (L - L.transpose()) / 2.0;
+
+  double w_np1[3];
+  rankTwoSkewToNEML(_linear_rotation[_qp], w_np1);
+  double w_n[3];
+  rankTwoSkewToNEML(_linear_rotation_old[_qp], w_n);
+
+  // Time
+  double t_np1 = _t;
+  double t_n = _t - _dt;
+
+  // Temperature
+  double T_np1 = _temperature[_qp];
+  double T_n = _temperature_old[_qp];
+
+  // Internal state
+  double * h_np1;
+  const double * h_n;
+
+  // Just to keep MOOSE debug happy
+  if (_model->nstore() > 0)
+  {
+    h_np1 = &(_history[_qp][0]);
+    h_n = &(_history_old[_qp][0]);
+  }
+  else
+  {
+    h_np1 = nullptr;
+    h_n = nullptr;
+  }
+
+  // Energy
+  double u_np1;
+  double u_n = _energy_old[_qp];
+
+  // Dissipation
+  double p_np1;
+  double p_n = _dissipation_old[_qp];
+
+  // Tangent
+  double A_np1[36];
+  double B_np1[18];
+
+  try
+  {
+    // Call NEML!
+    if (_large_kinematics)
+    {
+      _model->update_ld_inc(e_np1,
+                            e_n,
+                            w_np1,
+                            w_n,
+                            T_np1,
+                            T_n,
+                            t_np1,
+                            t_n,
+                            s_np1,
+                            s_n,
+                            h_np1,
+                            h_n,
+                            A_np1,
+                            B_np1,
+                            u_np1,
+                            u_n,
+                            p_np1,
+                            p_n);
+    }
+    else
+    {
+      _model->update_sd(e_np1,
+                        e_n,
+                        T_np1,
+                        T_n,
+                        t_np1,
+                        t_n,
+                        s_np1,
+                        s_n,
+                        h_np1,
+                        h_n,
+                        A_np1,
+                        u_np1,
+                        u_n,
+                        p_np1,
+                        p_n);
+      std::fill(B_np1, B_np1 + 18, 0.0);
+    }
+
+    double estrain[6];
+    _model->elastic_strains(s_np1, T_np1, h_np1, estrain);
+
+    // Translate back from Mandel notation
+    NEMLStressBase::nemlToRankTwoTensor(s_np1, _cauchy_stress[_qp]);
+    recombineTangentNEML(A_np1, B_np1, _cauchy_jacobian[_qp]);
+    _energy[_qp] = u_np1;
+    _dissipation[_qp] = p_np1;
+    _dissipation_rate[_qp] = (p_np1 - p_n) / (t_np1 - t_n);
+
+    NEMLStressBase::nemlToRankTwoTensor(estrain, _elastic_strain[_qp]);
+    _inelastic_strain[_qp] = _mechanical_strain[_qp] - _elastic_strain[_qp];
+  }
+  catch (const neml::NEMLError & e)
+  {
+    throw MooseException("NEML error: " + e.message());
+  }
+}
+
+void
+CauchyStressFromNEML::initQpStatefulProperties()
+{
+  ComputeLagrangianStressCauchy::initQpStatefulProperties();
+
+  _history[_qp].resize(_model->nstore());
+  try
+  {
+    // This is only needed because MOOSE whines about zero sized vectors
+    // that are not initialized
+    if (_history[_qp].size() > 0)
+      _model->init_store(&_history[_qp].front());
+  }
+  catch (const neml::NEMLError & e)
+  {
+    throw MooseException("NEML error: " + e.message());
+  }
+
+  _linear_rotation[_qp].zero();
+
+  _energy[_qp] = 0.0;
+  _dissipation[_qp] = 0.0;
+  _dissipation_rate[_qp] = 0.0;
+}
+
+void
+rankTwoSkewToNEML(const RankTwoTensor & in, double * const out)
+{
+  out[0] = -in(1, 2);
+  out[1] = in(0, 2);
+  out[2] = -in(0, 1);
+}
+
+void
+recombineTangentNEML(const double * const Dpart, const double * const Wpart, RankFourTensor & out)
+{
+  std::vector<double> data(81);
+  neml::transform_fourth(Dpart, Wpart, &data[0]);
+  out.fillFromInputVector(data, RankFourTensor::FillMethod::general);
+}
+
+#endif // NEML_ENABLED

--- a/src/materials/NEMLStressBase.C
+++ b/src/materials/NEMLStressBase.C
@@ -204,7 +204,7 @@ NEMLStressBase::initQpStatefulProperties()
   {
     try
     {
-      _model->init_hist(_hist[_qp].data());
+      _model->init_store(_hist[_qp].data());
     }
     catch (const neml::NEMLError & e)
     {

--- a/test/tests/neml_lagrangian_jacobian/jactest.i
+++ b/test/tests/neml_lagrangian_jacobian/jactest.i
@@ -1,0 +1,147 @@
+# Simple 3D test
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Mesh]
+  [msh]
+    type = GeneratedMeshGenerator
+    dim = 3
+    nx = 4
+    ny = 4
+    nz = 4
+  []
+[]
+
+[Modules]
+  [TensorMechanics]
+    [Master]
+      [all]
+        strain = SMALL
+        add_variables = true
+        new_system = true
+        formulation = UPDATED
+        volumetric_locking_correction = true
+        generate_output = 'cauchy_stress_xx cauchy_stress_yy cauchy_stress_zz cauchy_stress_xy '
+                          'cauchy_stress_xz cauchy_stress_yz mechanical_strain_xx mechanical_strain_yy mechanical_strain_zz mechanical_strain_xy '
+                          'mechanical_strain_xz mechanical_strain_yz'
+      []
+    []
+  []
+[]
+
+[ICs]
+  [disp_x]
+    type = RandomIC
+    variable = disp_x
+    min = -0.02
+    max = 0.02
+  []
+  [disp_y]
+    type = RandomIC
+    variable = disp_y
+    min = -0.02
+    max = 0.02
+  []
+  [disp_z]
+    type = RandomIC
+    variable = disp_z
+    min = -0.02
+    max = 0.02
+  []
+[]
+
+[Functions]
+  [pullx]
+    type = ParsedFunction
+    value = '4000 * t'
+  []
+  [pully]
+    type = ParsedFunction
+    value = '-2000 * t'
+  []
+  [pullz]
+    type = ParsedFunction
+    value = '3000 * t'
+  []
+[]
+
+[BCs]
+  [leftx]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = disp_x
+    value = 0.0
+  []
+  [lefty]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = disp_y
+    value = 0.0
+  []
+  [leftz]
+    type = DirichletBC
+    preset = true
+    boundary = left
+    variable = disp_z
+    value = 0.0
+  []
+  [pull_x]
+    type = FunctionNeumannBC
+    boundary = right
+    variable = disp_x
+    function = pullx
+  []
+  [pull_y]
+    type = FunctionNeumannBC
+    boundary = top
+    variable = disp_y
+    function = pully
+  []
+  [pull_z]
+    type = FunctionNeumannBC
+    boundary = right
+    variable = disp_z
+    function = pullz
+  []
+[]
+
+[Materials]
+  [./stress]
+    type = CauchyStressFromNEML
+    database = "test_materials.xml"
+    model = "elastic_model"
+    large_kinematics = false
+  [../]
+[]
+
+[Preconditioning]
+  [smp]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+
+  solve_type = 'newton'
+  line_search = none
+
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+
+  l_max_its = 2
+  l_tol = 1e-14
+  nl_max_its = 15
+  nl_rel_tol = 1e-8
+  nl_abs_tol = 1e-10
+
+  start_time = 0.0
+  dt = 1.0
+  dtmin = 1.0
+  end_time = 1.0
+[]

--- a/test/tests/neml_lagrangian_jacobian/test_materials.xml
+++ b/test/tests/neml_lagrangian_jacobian/test_materials.xml
@@ -1,0 +1,68 @@
+<materials>
+  <elastic_model type="SmallStrainElasticity">
+    <elastic type="IsotropicLinearElasticModel">
+      <m1_type>youngs</m1_type>
+      <m1>150000.0</m1>
+      <m2_type>poissons</m2_type>
+      <m2>0.3</m2>
+    </elastic>
+  </elastic_model>
+  <chaboche_model type="GeneralIntegrator">
+    <elastic type="IsotropicLinearElasticModel">
+      <m1>60384.61</m1>
+      <m1_type>shear</m1_type>
+      <m2>130833.3</m2>
+      <m2_type>bulk</m2_type>
+    </elastic>
+    
+    <rule type="TVPFlowRule">
+      <elastic type="IsotropicLinearElasticModel">
+        <m1>60384.61</m1>
+        <m1_type>shear</m1_type>
+        <m2>130833.3</m2>
+        <m2_type>bulk</m2_type>
+      </elastic>
+
+      <flow type="ChabocheFlowRule">
+        <surface type="IsoKinJ2"/>
+        <hardening type="Chaboche">
+          <iso type="VoceIsotropicHardeningRule">
+            <s0>0.0</s0>
+            <R>-80.0</R>
+            <d>3.0</d>
+          </iso>
+          <C>
+            <C1>135.0e3</C1>
+            <C2>61.0e3</C2>
+            <C3>11.0e3</C3>
+          </C>
+          <gmodels>
+            <g1 type="ConstantGamma">
+              <g>5.0e4</g>
+            </g1>
+            <g2 type="ConstantGamma">
+              <g>1100.0</g>
+            </g2>
+            <g3 type="ConstantGamma">
+              <g>1.0</g>
+            </g3>
+          </gmodels>
+          <A>
+            <A1>0.0</A1>
+            <A2>0.0</A2>
+            <A3>0.0</A3>
+          </A>
+          <a>
+            <a1>1.0</a1>
+            <a2>1.0</a2>
+            <a3>1.0</a3>
+          </a>
+        </hardening>
+        <fluidity type="ConstantFluidity">
+          <eta>701.0</eta>
+        </fluidity>
+        <n>10.5</n>
+      </flow>
+    </rule>
+  </chaboche_model>
+</materials>

--- a/test/tests/neml_lagrangian_jacobian/tests
+++ b/test/tests/neml_lagrangian_jacobian/tests
@@ -6,6 +6,7 @@
     difference_tol = 1E10
     cli_args = "Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/formulation=TOTAL Materials/stress/large_kinematics=false"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for small strain kinematics using the total Lagrangian formulation'
+    issues = '#312'
   [../]
   [./small_updated]
     type = PetscJacobianTester
@@ -14,6 +15,7 @@
     difference_tol = 1E10
     cli_args = "Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/formulation=UPDATED Materials/stress/large_kinematics=false"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for small strain kinematics using the updated Lagrangian formulation'
+    issues = '#312'
   [../]
   [./large_total]
     type = PetscJacobianTester
@@ -22,6 +24,7 @@
     difference_tol = 1E10
     cli_args = "Modules/TensorMechanics/Master/all/strain=FINITE Modules/TensorMechanics/Master/all/formulation=TOTAL Materials/stress/large_kinematics=true"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for large strain kinematics using the total Lagrangian formulation'
+    issues = '#312'
   [../]
   [./large_updated]
     type = PetscJacobianTester
@@ -30,5 +33,6 @@
     difference_tol = 1E10
     cli_args = "Modules/TensorMechanics/Master/all/strain=FINITE Modules/TensorMechanics/Master/all/formulation=UPDATED Materials/stress/large_kinematics=true"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for large strain kinematics using the updated Lagrangian formulation'
+    issues = '#312'
   [../]
 []

--- a/test/tests/neml_lagrangian_jacobian/tests
+++ b/test/tests/neml_lagrangian_jacobian/tests
@@ -1,0 +1,34 @@
+[Tests]
+  [./small_total]
+    type = PetscJacobianTester
+    input = 'jactest.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = "Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/formulation=TOTAL Materials/stress/large_kinematics=false"
+    requirement = 'Jacobian is exact with relative tolerance of 1e-7 for small strain kinematics using the total Lagrangian formulation'
+  [../]
+  [./small_updated]
+    type = PetscJacobianTester
+    input = 'jactest.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = "Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/formulation=UPDATED Materials/stress/large_kinematics=false"
+    requirement = 'Jacobian is exact with relative tolerance of 1e-7 for small strain kinematics using the updated Lagrangian formulation'
+  [../]
+  [./large_total]
+    type = PetscJacobianTester
+    input = 'jactest.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = "Modules/TensorMechanics/Master/all/strain=FINITE Modules/TensorMechanics/Master/all/formulation=TOTAL Materials/stress/large_kinematics=true"
+    requirement = 'Jacobian is exact with relative tolerance of 1e-7 for large strain kinematics using the total Lagrangian formulation'
+  [../]
+  [./large_updated]
+    type = PetscJacobianTester
+    input = 'jactest.i'
+    ratio_tol = 1E-7
+    difference_tol = 1E10
+    cli_args = "Modules/TensorMechanics/Master/all/strain=FINITE Modules/TensorMechanics/Master/all/formulation=UPDATED Materials/stress/large_kinematics=true"
+    requirement = 'Jacobian is exact with relative tolerance of 1e-7 for large strain kinematics using the updated Lagrangian formulation'
+  [../]
+[]

--- a/test/tests/neml_lagrangian_jacobian/tests
+++ b/test/tests/neml_lagrangian_jacobian/tests
@@ -7,6 +7,7 @@
     cli_args = "Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/formulation=TOTAL Materials/stress/large_kinematics=false"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for small strain kinematics using the total Lagrangian formulation'
     issues = '#312'
+    design = 'CauchyStressFromNEML.md'
   [../]
   [./small_updated]
     type = PetscJacobianTester
@@ -16,6 +17,7 @@
     cli_args = "Modules/TensorMechanics/Master/all/strain=SMALL Modules/TensorMechanics/Master/all/formulation=UPDATED Materials/stress/large_kinematics=false"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for small strain kinematics using the updated Lagrangian formulation'
     issues = '#312'
+    design = 'CauchyStressFromNEML.md'
   [../]
   [./large_total]
     type = PetscJacobianTester
@@ -25,6 +27,7 @@
     cli_args = "Modules/TensorMechanics/Master/all/strain=FINITE Modules/TensorMechanics/Master/all/formulation=TOTAL Materials/stress/large_kinematics=true"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for large strain kinematics using the total Lagrangian formulation'
     issues = '#312'
+    design = 'CauchyStressFromNEML.md'
   [../]
   [./large_updated]
     type = PetscJacobianTester
@@ -34,5 +37,6 @@
     cli_args = "Modules/TensorMechanics/Master/all/strain=FINITE Modules/TensorMechanics/Master/all/formulation=UPDATED Materials/stress/large_kinematics=true"
     requirement = 'Jacobian is exact with relative tolerance of 1e-7 for large strain kinematics using the updated Lagrangian formulation'
     issues = '#312'
+    design = 'CauchyStressFromNEML.md'
   [../]
 []

--- a/test/tests/neml_regression/populate_tests.py
+++ b/test/tests/neml_regression/populate_tests.py
@@ -35,7 +35,7 @@ test_string = """  [{testname}]
     input = 'neml_regression.i'
     cli_args = 'GlobalParams/data_file=../../../contrib/neml/test/test_regression/{testname}/data.csv Materials/stress/database=../../../contrib/neml/test/test_regression/{testname}/model.xml Outputs/csv/file_base={testname}_out'
     csvdiff = '{testname}_out.csv'
-    rel_err = 1e-5
+    rel_err = 1e-4
     abs_zero = {abs_zero}
     required_objects = NEMLStress
     issues = '#197'

--- a/test/tests/neml_regression_lagrangian/.gitignore
+++ b/test/tests/neml_regression_lagrangian/.gitignore
@@ -1,0 +1,2 @@
+tests
+gold/*.csv

--- a/test/tests/neml_regression_lagrangian/neml_regression.i
+++ b/test/tests/neml_regression_lagrangian/neml_regression.i
@@ -1,0 +1,295 @@
+# This is a common input file that can be used for all NEML regression tests, which
+# use a material driver.
+# Notes:
+# 1) A single csv file provides both the expected temperature and strain inputs and
+#    stress outputs. This file is almost identical to the one used in the NEML tests,
+#    is named 'test_x_out.csv', and lives in the 'gold' directory. The only change
+#    made to this file is that a first row with headings is added. It may seem odd
+#    to use the same file for the inputs and the gold results, but it facilitates
+#    supplying and comparing to the NEML regression tests.
+# 2) Mandel notation is used in the ordering of the stress/strain components in this
+#    file. There is a scaling factor of sqrt(2) used in converting between those and
+#    the tensor components used in MOOSE.
+# 3) Because all DOFs on the nodes of the single element are fully prescribed, there
+#    is no solution needed, so every step solves with no iterations.
+# 4) The computations are a bit slow will full integration. Single point integration
+#    can be used here without changing the solution, and is employed to accelerate
+#    these computations.
+
+# This version uses the Lagrangian kernels and the corresponding NEML driver
+
+[GlobalParams]
+  displacements = 'disp_x disp_y disp_z'
+[]
+
+[Mesh]
+  [cube]
+    type = GeneratedMeshGenerator
+    dim = 3
+  []
+[]
+
+[Modules/TensorMechanics/Master]
+  [all]
+    new_system = true
+    formulation = TOTAL
+    strain = SMALL
+    generate_output = 'strain_xx strain_yy strain_zz strain_xy strain_yz strain_xz
+                       cauchy_stress_xx cauchy_stress_yy cauchy_stress_zz cauchy_stress_xy cauchy_stress_yz cauchy_stress_xz'
+    add_variables = true
+  []
+[]
+
+[AuxVariables]
+  [temperature]
+  []
+[]
+
+[AuxKernels]
+  [temperature]
+    type = FunctionAux
+    function = temperature
+    variable = temperature
+    execute_on = 'initial timestep_begin'
+  []
+[]
+
+
+[BCs]
+  [x]
+    type = FunctionDirichletBC
+    variable = disp_x
+    boundary = 'left right back front bottom top'
+    function = u_x
+  []
+  [y]
+    type = FunctionDirichletBC
+    variable = disp_y
+    boundary = 'left right back front bottom top'
+    function = u_y
+  []
+  [z]
+    type = FunctionDirichletBC
+    variable = disp_z
+    boundary = 'left right back front bottom top'
+    function = u_z
+  []
+[]
+
+[Functions]
+  [temperature]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 1
+  []
+  [strain_xx]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 2
+  []
+  [strain_yy]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 3
+  []
+  [strain_zz]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 4
+  []
+  [strain_yz]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 5
+  []
+  [strain_xz]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 6
+  []
+  [strain_xy]
+    type = PiecewiseLinear
+    format = columns
+    xy_in_file_only = false
+    x_index_in_file = 0
+    y_index_in_file = 7
+  []
+  [u_x]
+    type = ParsedFunction
+    vars = 'strain_xx strain_xy strain_xz'
+    vals = 'strain_xx strain_xy strain_xz'
+    value = 'x*strain_xx + 1/sqrt(2)*y*strain_xy + 1/sqrt(2)*z*strain_xz'
+  []
+  [u_y]
+    type = ParsedFunction
+    vars = 'strain_yy strain_xy strain_yz'
+    vals = 'strain_yy strain_xy strain_yz'
+    value = 'y*strain_yy + 1/sqrt(2)*x*strain_xy + 1/sqrt(2)*z*strain_yz'
+  []
+  [u_z]
+    type = ParsedFunction
+    vars = 'strain_zz strain_xz strain_yz'
+    vals = 'strain_zz strain_xz strain_yz'
+    value = 'z*strain_zz + 1/sqrt(2)*x*strain_xz + 1/sqrt(2)*y*strain_yz'
+  []
+[]
+
+[Materials]
+  [stress]
+    type = CauchyStressFromNEML
+    model = 'model'
+    temperature = temperature
+    large_kinematics = false
+  []
+[]
+
+[Postprocessors]
+  [stress_11]
+    type = ElementAverageValue
+    variable = cauchy_stress_xx
+    execute_on = 'initial timestep_end'
+  []
+  [stress_22]
+    type = ElementAverageValue
+    variable = cauchy_stress_yy
+    execute_on = 'initial timestep_end'
+  []
+  [stress_33]
+    type = ElementAverageValue
+    variable = cauchy_stress_zz
+    execute_on = 'initial timestep_end'
+  []
+  [stress_12_tensor]
+    type = ElementAverageValue
+    variable = cauchy_stress_xy
+    execute_on = 'initial timestep_end'
+    outputs = none
+  []
+  [stress_12]
+    type = LinearCombinationPostprocessor
+    pp_names = 'stress_12_tensor'
+    pp_coefs = '1.41421356237'
+    execute_on = 'initial timestep_end'
+  []
+  [stress_13_tensor]
+    type = ElementAverageValue
+    variable = cauchy_stress_xz
+    execute_on = 'initial timestep_end'
+    outputs = none
+  []
+  [stress_13]
+    type = LinearCombinationPostprocessor
+    pp_names = 'stress_13_tensor'
+    pp_coefs = '1.41421356237'
+    execute_on = 'initial timestep_end'
+  []
+  [stress_23_tensor]
+    type = ElementAverageValue
+    variable = cauchy_stress_yz
+    execute_on = 'initial timestep_end'
+    outputs = none
+  []
+  [stress_23]
+    type = LinearCombinationPostprocessor
+    pp_names = 'stress_23_tensor'
+    pp_coefs = '1.41421356237'
+    execute_on = 'initial timestep_end'
+  []
+  [strain_11]
+    type = ElementAverageValue
+    variable = strain_xx
+    execute_on = 'initial timestep_end'
+  []
+  [strain_22]
+    type = ElementAverageValue
+    variable = strain_yy
+    execute_on = 'initial timestep_end'
+  []
+  [strain_33]
+    type = ElementAverageValue
+    variable = strain_zz
+    execute_on = 'initial timestep_end'
+  []
+  [strain_12_tensor]
+    type = ElementAverageValue
+    variable = strain_xy
+    execute_on = 'initial timestep_end'
+    outputs = none
+  []
+  [strain_12]
+    type = LinearCombinationPostprocessor
+    pp_names = 'strain_12_tensor'
+    pp_coefs = '1.41421356237'
+    execute_on = 'initial timestep_end'
+  []
+  [strain_13_tensor]
+    type = ElementAverageValue
+    variable = strain_xz
+    execute_on = 'initial timestep_end'
+    outputs = none
+  []
+  [strain_13]
+    type = LinearCombinationPostprocessor
+    pp_names = 'strain_13_tensor'
+    pp_coefs = '1.41421356237'
+    execute_on = 'initial timestep_end'
+  []
+  [strain_23_tensor]
+    type = ElementAverageValue
+    variable = strain_yz
+    execute_on = 'initial timestep_end'
+    outputs = none
+  []
+  [strain_23]
+    type = LinearCombinationPostprocessor
+    pp_names = 'strain_23_tensor'
+    pp_coefs = '1.41421356237'
+    execute_on = 'initial timestep_end'
+  []
+  [temperature]
+    type = ElementAverageValue
+    variable = temperature
+    execute_on = 'initial timestep_end'
+  []
+[]
+
+[Executioner]
+  type = Transient
+  solve_type = 'NEWTON'
+  [Quadrature]
+    order = FIRST #Single qp to make this fully prescribed, single-element test run faster
+  []
+
+  l_max_its = 5
+  l_tol = 1e-14
+  nl_max_its = 10
+  nl_rel_tol = 1e-10
+  nl_abs_tol = 1e-12
+  nl_forced_its = 2
+  line_search = none
+
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+
+  end_time = 1000.0
+  dt = 10.0
+[]
+
+[Outputs]
+  [csv]
+    type = CSV
+  []
+  exodus = true
+[]

--- a/test/tests/neml_regression_lagrangian/populate_tests.py
+++ b/test/tests/neml_regression_lagrangian/populate_tests.py
@@ -38,7 +38,7 @@ test_string = """  [{testname}]
     rel_err = 1e-4
     abs_zero = {abs_zero}
     required_objects = NEMLStress
-    issues = '#197'
+    issues = '#312'
     design = 'NEMLStress.md'
     requirement = 'BlackBear shall run {testname} of the NEML regression tests and obtain equivalent results to those from the NEML material driver'
 {skip}  []

--- a/test/tests/neml_regression_lagrangian/populate_tests.py
+++ b/test/tests/neml_regression_lagrangian/populate_tests.py
@@ -37,9 +37,9 @@ test_string = """  [{testname}]
     csvdiff = '{testname}_out.csv'
     rel_err = 1e-4
     abs_zero = {abs_zero}
-    required_objects = NEMLStress
+    required_objects = CauchyStressFromNEML
     issues = '#312'
-    design = 'NEMLStress.md'
+    design = 'CauchyStressFromNEML.md'
     requirement = 'BlackBear shall run {testname} of the NEML regression tests and obtain equivalent results to those from the NEML material driver'
 {skip}  []
 """

--- a/test/tests/neml_regression_lagrangian/populate_tests.py
+++ b/test/tests/neml_regression_lagrangian/populate_tests.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import os
+
+print('Populating NEML regression tests, Lagrangian system')
+NEML_DIR = os.environ['NEML_DIR']
+neml_rtest_path = os.path.relpath(NEML_DIR + '/test/test_regression')
+dirs = []
+
+for (dirpath, dirnames, filenames) in os.walk(neml_rtest_path):
+  if '__pycache__' in dirnames:
+    dirnames.remove("__pycache__")
+  dirs.extend(dirnames)
+
+try:
+  os.mkdir('gold')
+except FileExistsError:
+  pass
+
+for d in dirs:
+  src = '../' + neml_rtest_path + '/' + d + '/data.csv'
+  dst = 'gold/' + d + '_out.csv'
+  try:
+    os.symlink(src, dst)
+  except FileExistsError:
+    os.remove(dst)
+    os.symlink(src, dst)
+
+testsfile = open("tests", "w")
+
+testsfile.write("[Tests]\n")
+
+test_string = """  [{testname}]
+    type = 'CSVDiff'
+    input = 'neml_regression.i'
+    cli_args = 'GlobalParams/data_file=../../../contrib/neml/test/test_regression/{testname}/data.csv Materials/stress/database=../../../contrib/neml/test/test_regression/{testname}/model.xml Outputs/csv/file_base={testname}_out'
+    csvdiff = '{testname}_out.csv'
+    rel_err = 1e-4
+    abs_zero = {abs_zero}
+    required_objects = NEMLStress
+    issues = '#197'
+    design = 'NEMLStress.md'
+    requirement = 'BlackBear shall run {testname} of the NEML regression tests and obtain equivalent results to those from the NEML material driver'
+{skip}  []
+"""
+
+abs_zero_overrides = {
+  'test_substep':             1e-7,
+  'test_basicchaboche':       1e-7,
+  'test_chabochefull':        5e-7,
+  'test_complexcreep':        1e-7,
+  'test_complexcreepdamage':  1e-7,
+  'test_walkerkremplswitch':  1e-7,
+  'test_plasticcreep':        1e-7,
+  'test_linearisokin':        1e-6,
+  'test_cpmulti':             5e-7,
+  'test_walkerbasic':         1e-7,
+  'test_cpbcc':               1e-7,
+  'test_cpsimple':            1e-7}
+
+#No test currently need to be skipped, but listing them here as
+#follows would skip them:
+# 'test_name':  "    skip = 'Skip message'\n"
+skip_overrides = {}
+
+for d in dirs:
+  abs_zero_d = abs_zero_overrides.get(d, 1e-8)
+  skip_d = skip_overrides.get(d, "")
+
+  testsfile.write(test_string.format(testname=d, abs_zero=abs_zero_d, skip=skip_d))
+
+testsfile.write("[]")


### PR DESCRIPTION
This updates the submodule version of NEML to the newest version, updates the `NEMLStress` material model to reflect NEML API changes, and adds a new drivers `CauchyStressFromNEML` which interfaces NEML directly with the Lagrangian system.

closes #312 