### PR TITLE
Set slow neml tests to valgrind=heavy

### DIFF
--- a/test/tests/neml_regression/populate_tests.py
+++ b/test/tests/neml_regression/populate_tests.py
@@ -41,7 +41,7 @@ test_string = """  [{testname}]
     issues = '#197'
     design = 'NEMLStress.md'
     requirement = 'BlackBear shall run {testname} of the NEML regression tests and obtain equivalent results to those from the NEML material driver'
-{skip}  []
+{skip}{valgrind}  []
 """
 
 abs_zero_overrides = {
@@ -55,6 +55,9 @@ abs_zero_overrides = {
   'test_linearisokin':        1e-6,
   'test_cpmulti':             5e-7}
 
+valgrind_overrides = {
+  'test_substep':             '    valgrind = heavy\n'}
+
 #No test currently need to be skipped, but listing them here as
 #follows would skip them:
 # 'test_name':  "    skip = 'Skip message'\n"
@@ -63,7 +66,8 @@ skip_overrides = {}
 for d in dirs:
   abs_zero_d = abs_zero_overrides.get(d, 1e-8)
   skip_d = skip_overrides.get(d, "")
+  valgrind_d = valgrind_overrides.get(d, "")
 
-  testsfile.write(test_string.format(testname=d, abs_zero=abs_zero_d, skip=skip_d))
+  testsfile.write(test_string.format(testname=d, abs_zero=abs_zero_d, skip=skip_d, valgrind=valgrind_d))
 
 testsfile.write("[]")

--- a/test/tests/neml_regression_lagrangian/populate_tests.py
+++ b/test/tests/neml_regression_lagrangian/populate_tests.py
@@ -41,7 +41,7 @@ test_string = """  [{testname}]
     issues = '#312'
     design = 'CauchyStressFromNEML.md'
     requirement = 'BlackBear shall run {testname} of the NEML regression tests and obtain equivalent results to those from the NEML material driver'
-{skip}  []
+{skip}{valgrind}  []
 """
 
 abs_zero_overrides = {
@@ -58,6 +58,9 @@ abs_zero_overrides = {
   'test_cpbcc':               1e-7,
   'test_cpsimple':            1e-7}
 
+valgrind_overrides = {
+  'test_substep':             '    valgrind = heavy\n'}
+
 #No test currently need to be skipped, but listing them here as
 #follows would skip them:
 # 'test_name':  "    skip = 'Skip message'\n"
@@ -66,7 +69,8 @@ skip_overrides = {}
 for d in dirs:
   abs_zero_d = abs_zero_overrides.get(d, 1e-8)
   skip_d = skip_overrides.get(d, "")
+  valgrind_d = valgrind_overrides.get(d, "")
 
-  testsfile.write(test_string.format(testname=d, abs_zero=abs_zero_d, skip=skip_d))
+  testsfile.write(test_string.format(testname=d, abs_zero=abs_zero_d, skip=skip_d, valgrind=valgrind_d))
 
 testsfile.write("[]")


### PR DESCRIPTION
 ref #310

Two of the NEML tests were failing the valgrind tests because they didn't run in the 600s limit. This updates the scripts that automatically generate the 'tests' files to set them to 'valgrind=heavy' to give them more time.
