### PR TITLE
Add default value for vector type input parameters

### DIFF
--- a/src/actions/EqualValueEmbeddedConstraintAction.C
+++ b/src/actions/EqualValueEmbeddedConstraintAction.C
@@ -35,6 +35,7 @@ EqualValueEmbeddedConstraintAction::validParams()
       "secondary", "The list of ids of the secondary block (subdomain) ");
   params.addParam<std::vector<VariableName>>(
       "primary_variable",
+      {},
       "The list of variables on the primary side (defaults to the specified value of 'variable')");
   params.addRequiredParam<std::vector<NonlinearVariableName>>(
       "variable", "The list of variables on the secondary side");

--- a/src/materials/NEMLStress.C
+++ b/src/materials/NEMLStress.C
@@ -30,7 +30,7 @@ NEMLStress::validParams()
   params.addClassDescription("Use a constitutive model in the NEML library to compute stress");
   params.addRequiredParam<FileName>("database", "Path to NEML XML database.");
   params.addRequiredParam<std::string>("model", "Model name in NEML database.");
-  params.addParam<std::vector<std::string>>("neml_variable_iname",
+  params.addParam<std::vector<std::string>>("neml_variable_iname", {},
                                             "Names of NEML XML name/value pairs");
   params.addParam<std::vector<Real>>("neml_variable_value",
                                      "Corresponding NEML XML variable values");

--- a/src/materials/NEMLStress.C
+++ b/src/materials/NEMLStress.C
@@ -30,8 +30,8 @@ NEMLStress::validParams()
   params.addClassDescription("Use a constitutive model in the NEML library to compute stress");
   params.addRequiredParam<FileName>("database", "Path to NEML XML database.");
   params.addRequiredParam<std::string>("model", "Model name in NEML database.");
-  params.addParam<std::vector<std::string>>("neml_variable_iname", {},
-                                            "Names of NEML XML name/value pairs");
+  params.addParam<std::vector<std::string>>(
+      "neml_variable_iname", {}, "Names of NEML XML name/value pairs");
   params.addParam<std::vector<Real>>("neml_variable_value",
                                      "Corresponding NEML XML variable values");
   for (size_t i = 0; i < _nvars_max; ++i)


### PR DESCRIPTION
## Bug Description
<!--A clear and concise description of the error, failure, fault, incorrect or unexpected result, or unintended behavior (Note: A missing feature is not a bug.).-->
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This new fix in MOOSE cause several tests failed in Blackbear which don't provide default value for vector parameter. 

## Impact
<!--Does this prevent you from getting your work done, or is it more of an annoyance?-->
This patch is made to fix the failed Blackbear tests due to the new changes in MOOSE