### PR TITLE
Add default value for neml_variable_value

### DIFF
--- a/src/materials/NEMLStress.C
+++ b/src/materials/NEMLStress.C
@@ -32,8 +32,8 @@ NEMLStress::validParams()
   params.addRequiredParam<std::string>("model", "Model name in NEML database.");
   params.addParam<std::vector<std::string>>(
       "neml_variable_iname", {}, "Names of NEML XML name/value pairs");
-  params.addParam<std::vector<Real>>("neml_variable_value",
-                                     "Corresponding NEML XML variable values");
+  params.addParam<std::vector<Real>>(
+      "neml_variable_value", {}, "Corresponding NEML XML variable values");
   for (size_t i = 0; i < _nvars_max; ++i)
   {
     auto istr = Moose::stringify(i);


### PR DESCRIPTION
<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [MOOSE Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->
Refer to the issue [#24455](https://github.com/idaholab/moose/issues/24455), a fix is introduced to MOOSE to properly report error when no default value is provided for vector type input parameter. This issue is up to fix the left out vector parameters in Blackbear since last patch. It has been a while since we made the patch in Blackbear to adapt the new changes in MOOSE because we are waiting for other apps finish merging first. Hopefully this is the last patch we need.