### PR TITLE
Update parameter descriptions to use new API

### DIFF
--- a/src/materials/ConcreteASREigenstrain.C
+++ b/src/materials/ConcreteASREigenstrain.C
@@ -39,9 +39,12 @@ ConcreteASREigenstrain::validParams()
   params.addRequiredRangeCheckedParam<Real>(
       "characteristic_time",
       "characteristic_time > 0.0",
-      "Chracteristic ASR time (in days) at reference temprature. (tau_C(T_0))");
+      "Chracteristic ASR time at reference temprature. (tau_C(T_0))");
+  params.setDocUnit("characteristic_time", "d");
   params.addRequiredParam<Real>("latency_time",
-                                "Latency ASR time (in days) at reference temprature (tau_L(T_0))");
+                                "Latency ASR time at reference temprature (tau_L(T_0))");
+  params.setDocUnit("latency_time", "d");
+  // WGA - energy units?
   params.addRangeCheckedParam<Real>("characteristic_activation_energy",
                                     5400.0,
                                     "characteristic_activation_energy > 0.0",
@@ -275,7 +278,7 @@ ConcreteASREigenstrain::computeResidual(unsigned qp, Real scalar)
   // Convert current temperature to Kelvin
   const Real T = _temperature[qp] + _temp_offset;
 
-  // ASR characteristic and latency times (in days)
+  // ASR characteristic and latency times (in )
   Real tau_c = _tau_c_T0 * std::exp(_Uc * (1.0 / T - 1.0 / _ref_temp));
   Real tau_L = f * _tau_L_T0 * std::exp(_UL * (1.0 / T - 1.0 / _ref_temp));
 
@@ -309,7 +312,7 @@ ConcreteASREigenstrain::computeDerivative(unsigned qp, Real scalar)
   // Convert current temperature to Kelvin
   const Real T = _temperature[qp] + _temp_offset;
 
-  // ASR characteristic and latency times (in days)
+  // ASR characteristic and latency times (in )
   Real tau_c = _tau_c_T0 * std::exp(_Uc * (1.0 / T - 1.0 / _ref_temp));
   Real tau_L = f * _tau_L_T0 * std::exp(_UL * (1.0 / T - 1.0 / _ref_temp));
 

--- a/src/materials/ConcreteExpansionEigenstrainBase.C
+++ b/src/materials/ConcreteExpansionEigenstrainBase.C
@@ -24,6 +24,7 @@ ConcreteExpansionEigenstrainBase::validParams()
       "expansion_type", expansion_type, "Type of expansion resulting from volumetric strain");
   params.addRangeCheckedParam<Real>(
       "compressive_strength", "compressive_strength > 0", "Compressive strength of concrete");
+  // WGA - unclear if units are needed?
   params.addRangeCheckedParam<Real>(
       "expansion_stress_limit",
       "expansion_stress_limit > 0",

--- a/src/materials/ConcreteExpansionMicrocrackingDamage.C
+++ b/src/materials/ConcreteExpansionMicrocrackingDamage.C
@@ -42,15 +42,18 @@ ConcreteExpansionMicrocrackingDamage::validParams()
                         "Correction factor by which the eigenstrain is multiplied before "
                         "evaluating the damage");
 
+  // WGA - [m/m] ???
   params.addRequiredRangeCheckedParam<Real>(
       "microcracking_initiation_strain",
       "microcracking_initiation_strain > 0",
-      "Linear strain at which the microcracking initiates (in [m/m])");
+      "Linear strain at which the microcracking initiates");
+  params.setDocUnit("microcracking_initiation_strain", "[m/m]");
 
   params.addRequiredRangeCheckedParam<Real>(
       "microcracking_strain_branch",
       "microcracking_strain_branch > 0",
-      "Parameter controlling the rate at which the microcracking increases (in [m/m])");
+      "Parameter controlling the rate at which the microcracking increases");
+  params.setDocUnit("microcracking_strain_branch", "[m/m]");
 
   params.addParam<Real>(
       "expansion_stress_limit",

--- a/src/materials/ConcreteLogarithmicCreepModel.C
+++ b/src/materials/ConcreteLogarithmicCreepModel.C
@@ -38,11 +38,15 @@ ConcreteLogarithmicCreepModel::validParams()
                                     1,
                                     "long_term_characteristic_time > 0",
                                     "Rate at which the long_term viscosity increases");
-  params.addCoupledVar("temperature", "Temperature variable [in Celsius]");
+  // WGA - using 0C for degrees celcius
+  params.addCoupledVar("temperature", "Temperature variable");
+  params.setDocUnit("temperature", "0C");
   params.addRangeCheckedParam<Real>("activation_temperature",
                                     "activation_temperature >= 0",
-                                    "Activation temperature for the creep [in Kelvin]");
-  params.addParam<Real>("reference_temperature", 20, "Reference temperature [in Celsius]");
+                                    "Activation temperature for the creep");
+  params.setDocUnit("activation_temperature", "K");
+  params.addParam<Real>("reference_temperature", 20, "Reference temperature");
+  params.setDocUnit("reference_temperature", "0C");
   params.addCoupledVar("humidity", "Humidity variable");
   params.addRangeCheckedParam<Real>("drying_creep_viscosity",
                                     "drying_creep_viscosity > 0",

--- a/src/materials/ConcreteThermalMoisture.C
+++ b/src/materials/ConcreteThermalMoisture.C
@@ -71,25 +71,36 @@ ConcreteThermalMoisture::validParams()
   params.addParam<MooseEnum>(
       "aggregate_pore_type", aggregate_pore_type, "aggregate pore structure");
 
-  params.addParam<Real>("cement_mass", "cement mass (kg) per m^3");
-  params.addParam<Real>("aggregate_mass", "aggregate mass (kg) per m^3");
+  // WGA - unclear if units for following two params is kg or kg/m^3 - assuming kg
+  params.addParam<Real>("cement_mass", "cement mass per m^3");
+  params.setDocUnit("cement_mass", "kg");
+  params.addParam<Real>("aggregate_mass", "aggregate mass per m^3");
+  params.setDocUnit("aggregate_mass", "kg");
   params.addParam<Real>("water_to_cement_ratio", "water to cement ratio");
   params.addParam<Real>("aggregate_vol_fraction", "volumetric fraction of aggregates");
   params.addParam<Real>("concrete_cure_time", "concrete curing time in days");
-  params.addParam<Real>("ref_density", "refernece density of porous media Kg/m^3");
-  params.addParam<Real>("ref_specific_heat", "reference specific heat of concrete J/Kg/0C");
+  params.addParam<Real>("ref_density", "refernece density of porous media");
+  params.setDocUnit("ref_density", "kg/m^3");
+  // WGA - Joules / Kilograms / ??? - what is 0C?
+  params.addParam<Real>("ref_specific_heat", "reference specific heat of concrete");
+  params.setDocUnit("ref_specific_heat", "J/kg/0C");
+  // WGA - Watts / Meters / ??? - what is C?
   params.addParam<Real>("ref_thermal_conductivity",
-                        "concrete reference thermal conductivity (W/m/C)");
+                        "concrete reference thermal conductivity");
+  params.setDocUnit("ref_thermal_conductivity", "W/m/C");
 
   // parameters for Bazant mositure transport model
-  params.addParam<Real>("D1", "empirical constants (m2/s)");
+  // WGA - m2 = m^2 ?? - assuming so?
+  params.addParam<Real>("D1", "empirical constants");
+  params.setDocUnit("D1", "m^2/s");
   params.addParam<Real>("n", "empirical constants");
   params.addParam<Real>("critical_relative_humidity", "empirical constants");
   params.addParam<Real>("coupled_moisture_diffusivity_factor",
                         "coupling coefficient mositure transfer due to heat");
 
   // parameters for Mensi's moisture model
-  params.addParam<Real>("A", "empirical constants (m2/s)");
+  params.addParam<Real>("A", "empirical constants");
+  params.setDocUnit("A", "m^2/s");
   params.addParam<Real>("B", "empirical constants");
 
   params.addCoupledVar("relative_humidity", "nonlinear variable name for rel. humidity");

--- a/src/materials/DamagePlasticityStressUpdate.C
+++ b/src/materials/DamagePlasticityStressUpdate.C
@@ -39,6 +39,7 @@ DamagePlasticityStressUpdate::validParams()
       "ft_ep_slope_factor_at_zero_ep",
       "ft_ep_slope_factor_at_zero_ep <= 1 & ft_ep_slope_factor_at_zero_ep >= 0",
       "slope of ft vs plastic strain curve at zero plastic strain");
+  // WGA - unit needed for this?
   params.addRequiredParam<Real>(
       "tensile_damage_at_half_tensile_strength",
       "fraction of the elastic recovery slope in tension at 0.5*ft0 after yielding");


### PR DESCRIPTION
ref #396

Using param.setDocUnit(...) to document the units of parameters that currently have units listed in their descriptions. This causes the units to show up in a separate part of the documentation page.