### PR TITLE
Use full relative path for neml submodule

### DIFF
--- a/doc/content/sqa/blackbear_sll.md
+++ b/doc/content/sqa/blackbear_sll.md
@@ -9,4 +9,4 @@ BlackBear relies on NEML, which is summarized as follows on the project website:
 > material models. While it was originally developed to model high temperature nuclear reactors, the
 > tool is general enough to apply to most types of structural materials.
 
-Current Version of NEML: [!git!submodule-hash url=https://github.com/Argonne-National-Laboratory/neml/commit](neml)
+Current Version of NEML: [!git!submodule-hash url=https://github.com/Argonne-National-Laboratory/neml/commit](contrib/neml)


### PR DESCRIPTION
Declare the full relative path where neml lives: contrib/neml

Closes #404

