### PR TITLE
Divert material output to CSV object when it is needed by downstream postprocessor

### DIFF
--- a/test/tests/AverageExtensionRatio/AverageExtensionRatio.i
+++ b/test/tests/AverageExtensionRatio/AverageExtensionRatio.i
@@ -164,6 +164,22 @@
   [../]
 []
 
+[AuxVariables]
+  [forces_x]
+    order = CONSTANT
+    family = MONOMIAL
+  []
+[]
+
+[AuxKernels]
+  [forces_x]
+    type = MaterialRealVectorValueAux
+    property = forces
+    variable = forces_x
+    execute_on = timestep_end
+  []
+[]
+
 [Materials]
   [./elasticity]
     type = ComputeElasticityBeam
@@ -171,8 +187,6 @@
     youngs_modulus = 30e6
     poissons_ratio = 0.3
     block = 0
-    outputs = exodus
-    output_properties = 'material_stiffness material_flexure'
   [../]
   [./strain]
     type = ComputeIncrementalBeamStrain
@@ -189,8 +203,6 @@
   [./stress]
     type = ComputeBeamResultants
     block = 0
-    outputs = exodus
-    output_properties = 'forces moments'
   [../]
 []
 
@@ -242,5 +254,4 @@
 
 [Outputs]
   csv = true
-  exodus = true
 []


### PR DESCRIPTION
refs #408

<!--
INCLUDE THE FOLLOWING IN THE PR DESCRIPTION
- Explain relevant design information for your change.
- Follow the [MOOSE Coding Standards](http://mooseframework.org/wiki/CodeStandards/).
- Submit or improve [Test Cases](http://mooseframework.org/wiki/MooseTraining/testing/).
- Reference a specific issue, place "refs #<issue>" or "closes #<issue>" (e.g., #closes #1234).
-->

Based on the conversation in https://github.com/idaholab/moose/pull/29820, I am doing a cleanup of the  materials output system, and some tests in blackbear need to be updated by setting Materials/*/outputs=csv explicitly for tests that need this for a downstream Postprocessor.

This change should fix the public app test failures that are happening in https://github.com/idaholab/moose/pull/29820, and it should not require any re-golding of blackbear tests
