### PR TITLE
Fix deprecated tests closes #318

### DIFF
--- a/assessment/asr_validation/wald2017b/analysis/A1-biaxial.i
+++ b/assessment/asr_validation/wald2017b/analysis/A1-biaxial.i
@@ -666,7 +666,7 @@
 
 [Postprocessors]
   [nelem]
-    type = NumElems
+    type = NumElements
   []
   [ndof]
     type = NumDOFs

--- a/assessment/asr_validation/wald2017b/analysis/A1-triaxial.i
+++ b/assessment/asr_validation/wald2017b/analysis/A1-triaxial.i
@@ -706,7 +706,7 @@
 
 [Postprocessors]
   [nelem]
-    type = NumElems
+    type = NumElements
   []
   [ndof]
     type = NumDOFs

--- a/assessment/asr_validation/wald2017b/analysis/A1-uniaxial.i
+++ b/assessment/asr_validation/wald2017b/analysis/A1-uniaxial.i
@@ -626,7 +626,7 @@
 
 [Postprocessors]
   [nelem]
-    type = NumElems
+    type = NumElements
   []
   [ndof]
     type = NumDOFs

--- a/assessment/asr_validation/wald2017b/analysis/A1-unreinforced.i
+++ b/assessment/asr_validation/wald2017b/analysis/A1-unreinforced.i
@@ -471,7 +471,7 @@
 
 [Postprocessors]
   [nelem]
-    type = NumElems
+    type = NumElements
   []
   [ndof]
     type = NumDOFs

--- a/assessment/asr_validation/wald2017b/analysis/A3-biaxial.i
+++ b/assessment/asr_validation/wald2017b/analysis/A3-biaxial.i
@@ -666,7 +666,7 @@
 
 [Postprocessors]
   [nelem]
-    type = NumElems
+    type = NumElements
   []
   [ndof]
     type = NumDOFs

--- a/test/tests/actions/tests
+++ b/test/tests/actions/tests
@@ -21,6 +21,7 @@
       detail = 'using the EqualValueEmbeddedConstraint action to '
                'automatically set up multiple constraints with the same '
                'results as without using the action.'
+      abs_zero = 1e-9
     []
     [with_action_multiple_blocks]
       prereq = EqualValueEmbeddedConstraintAction/with_action

--- a/test/tests/rebar_bondslip/RCBeam_elastic_constraint.i
+++ b/test/tests/rebar_bondslip/RCBeam_elastic_constraint.i
@@ -6,31 +6,21 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
-      [Concrete_block]
-        block = 1
-        strain = small
-        incremental = true
-        generate_output = 'stress_xx strain_xx'
-      []
-    []
+[Physics/SolidMechanics/QuasiStatic]
+  [Concrete_block]
+    block = 1
+    strain = small
+    incremental = true
+    generate_output = 'stress_xx strain_xx'
   []
 []
 
-[Physics]
-  [SolidMechanics]
-    [LineElement]
-      [QuasiStatic]
-        [Reinforcement_block]
-          block = '2'
-          truss = true
-          area = area
-          displacements = 'disp_x disp_y'
-        []
-      []
-    []
+[Physics/SolidMechanics/LineElement/QuasiStatic]
+  [Reinforcement_block]
+    block = '2'
+    truss = true
+    area = area
+    displacements = 'disp_x disp_y'
   []
 []
 

--- a/test/tests/rebar_bondslip/RCBeam_elastic_constraint_45Deg.i
+++ b/test/tests/rebar_bondslip/RCBeam_elastic_constraint_45Deg.i
@@ -15,31 +15,21 @@
   displacements = 'disp_x disp_y'
 []
 
-[Modules]
-  [TensorMechanics]
-    [Master]
-      [Concrete_block]
-        block = 1
-        strain = small
-        incremental = true
-        generate_output = 'stress_xx strain_xx'
-      []
-    []
+[Physics/SolidMechanics/QuasiStatic]
+  [Concrete_block]
+    block = 1
+    strain = small
+    incremental = true
+    generate_output = 'stress_xx strain_xx'
   []
 []
 
-[Physics]
-  [SolidMechanics]
-    [LineElement]
-      [QuasiStatic]
-        [Reinforcement_block]
-          block = '2'
-          truss = true
-          area = area
-          displacements = 'disp_x disp_y'
-        []
-      []
-    []
+[Physics/SolidMechanics/LineElement/QuasiStatic]
+  [Reinforcement_block]
+    block = '2'
+    truss = true
+    area = area
+    displacements = 'disp_x disp_y'
   []
 []
 


### PR DESCRIPTION
closes #318
Most of the changes are removing outdated syntax. There's also a minor tolerance tweak to fix a diffing test that is unrelated to the syntax changes.